### PR TITLE
Fix RN autolinking configuration

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -9,8 +9,8 @@ pluginManagement {
 rootProject.name = 'tekerApp'
 include ':app'
 
+// Apply React Native CLI autolinking settings
+apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle")
+applyNativeModulesSettingsGradle(settings)
 
 includeBuild('../node_modules/@react-native/gradle-plugin')
-
-// Use ONLY the settings function
-applyNativeModulesSettingsGradle(settings)  // ✅ Correct for settings.gradle

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   project: {
     android: {
-      sourceDir: './android/app', // Verify this path
-      packageName: 'com.yourpackage.name' // MUST match AndroidManifest.xml & build.gradle
+      sourceDir: './android',
+      packageName: 'com.teker.tekerapp'
     }
   }
 };


### PR DESCRIPTION
## Summary
- correct settings.gradle to load `native_modules.gradle`
- align `react-native.config.js` with package name

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `sh ./gradlew tasks --no-daemon` *(partial download & execution)*

------
https://chatgpt.com/codex/tasks/task_e_685517cd4f60832bb5799fe6d6cc185e