### PR TITLE
Fix autolinking configuration

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -2,7 +2,7 @@ module.exports = {
   project: {
     ios: {},
     android: {
-      sourceDir: '../android',
+      sourceDir: './android',
       appName: 'app',
       packageName: 'com.teker.tekerapp',
     },


### PR DESCRIPTION
## Summary
- fix incorrect android path in `react-native.config.js` causing CLI failures

## Testing
- `npx react-native config --platform android | tail -n 20`
- `./gradlew clean` *(fails: Java home invalid in container)*

------
https://chatgpt.com/codex/tasks/task_e_685aa53e5354832bb39588b57c7f0e0f