### PR TITLE
Remove manual linkage for gesture handler modules

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -115,8 +115,6 @@ dependencies {
 
     implementation("org.bouncycastle:bcprov-jdk18on:1.76")
 
-    implementation project(':react-native-gesture-handler')
-    implementation project(':react-native-reanimated')
     
     // Hermes or JSC (JavaScript engine)
     if (hermesEnabled.toBoolean()) {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -41,9 +41,3 @@ dependencyResolutionManagement {
 
 rootProject.name = "tekerapp"
 include(":app")
-
-include ':react-native-gesture-handler'
-project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
-
-include ':react-native-reanimated'
-project(':react-native-reanimated').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-reanimated/android')


### PR DESCRIPTION
## Summary
- remove obsolete entries for `react-native-gesture-handler` and `react-native-reanimated` from Gradle

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*
- `./gradlew clean assembleDebug` *(fails: Java home supplied is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6877575ed814832b8a99726f92bfbfa4